### PR TITLE
automatically resize images (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 .bundle/
 .idea/
 .sass-cache/
+cache/

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-titles-from-headings"
   gem "jekyll-relative-links"
+  gem "jekyll-resize", git: "https://github.com/MichaelCurrin/jekyll-resize"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ plugins:
   - jekyll-paginate
   - jekyll-titles-from-headings
   - jekyll-relative-links
+  - jekyll-resize
 collections:
   projects:
     output: true

--- a/_includes/projectpreview.html
+++ b/_includes/projectpreview.html
@@ -1,18 +1,21 @@
 <div class="pubWrapper">
-	<div class="pubImage">
-		<img src="{{ include.item.image }}" alt="{{ include.item.img_alt }}" />
-	</div>
+  <div class="pubImage">
+    {% if include.item.image %}
+    <img
+      src='{{ include.item.image | resize: "800x800>" }}'
+      alt="{{ include.item.img_alt }}" />
+    {% endif %}
+  </div>
 
-	<div class="pubText">
-		<p>
-			<a
-				href="{{ include.item.url }}"
-				style="font-weight: bold; font-size: 1.2em;"
-			   
-				target="_blank"
-				>{{ include.item.title }}</a
-			>: {{ include.item.description }}.
-		</p>
-		<br/>
-	</div>
+  <div class="pubText">
+    <p>
+      <a
+        href="{{ include.item.url }}"
+        style="font-weight: bold; font-size: 1.2em"
+        target="_blank"
+        >{{ include.item.title }}</a
+      >: {{ include.item.description }}.
+    </p>
+    <br />
+  </div>
 </div>

--- a/_includes/publication.html
+++ b/_includes/publication.html
@@ -1,29 +1,30 @@
 <div class="pubWrapper">
-	<div class="pubImage">
-		<img
-			src="/figures/{{ include.item.img }}"
-			alt="{{ include.item.img_alt }}"
-		/>
-	</div>
+  <div class="pubImage">
+    {% if include.item.img %}
+    <img
+      src='{{ "/figures/" | append: include.item.img | resize: "800x800>" }}'
+      alt="{{ include.item.img_alt }}" />
+    {% endif %}
+  </div>
 
-	<div class="pubText">
-		<p>
-			<a
-				href="{{ include.item.paperlink }}"
-				style="font-weight: bold"
-				target="_blank"
-				>{{ include.item.title }}</a
-			>: {{ include.item.authors }}.
-			<i>{{ include.item.journal_conf }}.</i>
-			({{ include.item.year}}). {% if include.item.weblink %}
-			<a href="{{ include.item.weblink }}" target="_blank">[WEB]</a>
-			{% endif %} {% if include.item.videolink %}
-			<a href="{{ include.item.videolink }}" target="_blank">[VIDEO]</a>
-			{% endif %}{% if include.item.awards %}
-			<span style="font-weight: bold; text-transform: uppercase"
-				>{{ include.item.awards }}</span
-			>
-			{% endif %}
-		</p>
-	</div>
+  <div class="pubText">
+    <p>
+      <a
+        href="{{ include.item.paperlink }}"
+        style="font-weight: bold"
+        target="_blank"
+        >{{ include.item.title }}</a
+      >: {{ include.item.authors }}.
+      <i>{{ include.item.journal_conf }}.</i>
+      ({{ include.item.year}}). {% if include.item.weblink %}
+      <a href="{{ include.item.weblink }}" target="_blank">[WEB]</a>
+      {% endif %} {% if include.item.videolink %}
+      <a href="{{ include.item.videolink }}" target="_blank">[VIDEO]</a>
+      {% endif %} {% if include.item.awards %}
+      <span style="font-weight: bold; text-transform: uppercase">
+        {{ include.item.awards }}
+      </span>
+      {% endif %}
+    </p>
+  </div>
 </div>

--- a/_projects/cultural_collections.md
+++ b/_projects/cultural_collections.md
@@ -1,13 +1,11 @@
 ---
 layout: project
 title: Visualizing Cultural Collection
-image: figures/wonderverse.png
+# image is missing - add and then uncomment this line
+# image: figures/wonderverse.png
 description: Selected projects on visualizing cultural collections.
 people:
-- Uta Hinrichs
+  - Uta Hinrichs
 publications:
-- 
+  -
 ---
-
-
-


### PR DESCRIPTION
Adds a plugin to automatically resize images on build, I've set it to max. 800x800px on the publications page, we could go even smaller, up to 500 would be ok I think.

Pros: Page loads much faster, especially the publications page which currently has many large images.

Cons: Site takes longer to build (i.e. changes take a few seconds/minutes longer to show up on the web).